### PR TITLE
Add /footnote slash command

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -64,12 +64,17 @@ export default function Editor({ value, onChange }: EditorProps) {
 		if (!view) return;
 		const cursorPos = view.state.selection.main.head;
 		const from = slashStartPosRef.current;
-		view.dispatch(
-			view.state.update({
-				changes: { from, to: cursorPos, insert: command.content },
-				selection: { anchor: from + command.content.length },
-			}),
-		);
+
+		if (command.action) {
+			command.action(view, from, cursorPos);
+		} else if (command.content) {
+			view.dispatch(
+				view.state.update({
+					changes: { from, to: cursorPos, insert: command.content },
+					selection: { anchor: from + command.content.length },
+				}),
+			);
+		}
 		setShowMenu(false);
 		view.focus();
 	};

--- a/src/index.css
+++ b/src/index.css
@@ -78,3 +78,37 @@ body {
 	border-radius: 0.375rem;
 	font-size: 1.2em;
 }
+
+/* Footnotes */
+.markdown-preview [data-footnote-ref] {
+	font-size: 0.75em;
+	vertical-align: super;
+	text-decoration: none;
+	color: #3b82f6;
+}
+
+.markdown-preview [data-footnote-ref]:hover {
+	text-decoration: underline;
+}
+
+.markdown-preview .footnotes {
+	margin-top: 2rem;
+	padding-top: 1rem;
+	border-top: 1px solid #e5e7eb;
+	font-size: 0.875em;
+	color: #6b7280;
+}
+
+.markdown-preview .footnotes ol {
+	padding-left: 1.5rem;
+}
+
+.markdown-preview .footnotes li {
+	margin-bottom: 0.25rem;
+}
+
+.markdown-preview [data-footnote-backref] {
+	text-decoration: none;
+	font-size: 0.75em;
+	color: #3b82f6;
+}


### PR DESCRIPTION
## What

Closes #5 

Adds a slash command for adding footnotes

## How

Adds a /footnote slash command that inserts a [^n] reference at the cursor and appends a [^n]: footnote text definition at the end of the document. Auto-increments the footnote number based on existing footnotes in the document.

Extends the SlashCommand interface with an optional action callback for dynamic commands. Adds CSS styles for footnote rendering in the markdown preview.

## Demo

https://github.com/user-attachments/assets/7e7d335f-f76c-46e7-a52e-82ad969883d9

## Recommended follow-up

I noticed that the slash command menu only appears when you're at the beginning of a line, which isn't ideal for footnotes since they're likely to happen inline. I think the `/link` slash command would also benefit from having the slash command menu appear inline. I'm thinking of opening a follow-up issue for this. Edit: issue opened here https://github.com/cassidoo/fancygist/issues/22