### PR TITLE
Allow slash command menu to appear inline

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -24,15 +24,22 @@ export default function Editor({ value, onChange }: EditorProps) {
 	const [searchQuery, setSearchQuery] = useState("");
 	const [selectedIndex, setSelectedIndex] = useState(0);
 	const slashStartPosRef = useRef(0);
+	const [isInlineTrigger, setIsInlineTrigger] = useState(false);
 
 	// Refs so the keymap always sees current state
 	const showMenuRef = useRef(false);
 	const selectedIndexRef = useRef(0);
 	const filteredCommandsRef = useRef<SlashCommand[]>([]);
 
-	const filteredCommands = slashCommands.filter((cmd) =>
-		cmd.label.toLowerCase().includes(searchQuery.toLowerCase()),
-	);
+	const filteredCommands = slashCommands.filter((cmd) => {
+		const matchesQuery = cmd.label
+			.toLowerCase()
+			.includes(searchQuery.toLowerCase());
+		if (isInlineTrigger) {
+			return matchesQuery && cmd.inline;
+		}
+		return matchesQuery;
+	});
 
 	useEffect(() => {
 		showMenuRef.current = showMenu;
@@ -130,11 +137,16 @@ export default function Editor({ value, onChange }: EditorProps) {
 		const cursorPosInLine = cursorPos - lineStart;
 
 		const beforeCursor = lineText.slice(0, cursorPosInLine);
-		const slashMatch = beforeCursor.match(/^\/(\w*)$/);
+		const slashMatch = beforeCursor.match(/(?:^|\s)\/(\w*)$/);
 
 		if (slashMatch) {
+			const isInline = slashMatch.index !== undefined && slashMatch.index > 0;
+			setIsInlineTrigger(isInline);
 			setSearchQuery(slashMatch[1]);
-			slashStartPosRef.current = lineStart;
+			const slashOffset = isInline
+				? slashMatch.index + 1
+				: slashMatch.index ?? 0;
+			slashStartPosRef.current = lineStart + slashOffset;
 			setSelectedIndex(0);
 
 			const coords = view.coordsAtPos(cursorPos);

--- a/src/components/SlashCommandMenu.tsx
+++ b/src/components/SlashCommandMenu.tsx
@@ -5,6 +5,7 @@ export interface SlashCommand {
 	label: string;
 	description: string;
 	content: string;
+	inline?: boolean;
 }
 
 export const slashCommands: SlashCommand[] = [
@@ -20,6 +21,7 @@ export const slashCommands: SlashCommand[] = [
 		label: "image",
 		description: "Insert an image",
 		content: "![Alt text](https://example.com/image.jpg)",
+		inline: true,
 	},
 	{
 		label: "quote",
@@ -78,21 +80,25 @@ export const slashCommands: SlashCommand[] = [
 		description: "Insert lorem ipsum text",
 		content:
 			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.",
+		inline: true,
 	},
 	{
 		label: "link",
 		description: "Insert a link",
 		content: "[Link text](https://example.com)",
+		inline: true,
 	},
 	{
 		label: "bold",
 		description: "Insert bold text",
 		content: "**bold text**",
+		inline: true,
 	},
 	{
 		label: "italic",
 		description: "Insert italic text",
 		content: "*italic text*",
+		inline: true,
 	},
 ];
 


### PR DESCRIPTION
## What

Changes the trigger regex from ^/(\w*)$ to (?:^|\s)/(\w*)$ so the menu appears when / follows whitespace or starts a line. Adds an inline flag to SlashCommand to filter block-level commands (tables, headings, lists, etc.) when triggered mid-line. Inline commands (image, link, bold, italic, dummytext) show in both contexts.

Closes #22

## Demo


https://github.com/user-attachments/assets/cb6baa5f-6365-4758-909d-562630fd3b22

