### PR TITLE
Auto-focus editor on page load

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -44,6 +44,14 @@ export default function Editor({ value, onChange }: EditorProps) {
 		filteredCommandsRef.current = filteredCommands;
 	});
 
+	// Auto-focus editor on mount
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			editorRef.current?.view?.focus();
+		}, 0);
+		return () => clearTimeout(timer);
+	}, []);
+
 	const doInsert = (command: SlashCommand) => {
 		const view = editorRef.current?.view;
 		if (!view) return;


### PR DESCRIPTION
Adds a useEffect in Editor.tsx that focuses the CodeMirror editor when the component mounts, so users can start typing immediately.

Closes #23