### PR TITLE
Fix redirect order for gists/create route

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -29,13 +29,13 @@
   status = 200
 
 [[redirects]]
-  from = "/api/gists/:id"
-  to = "/.netlify/functions/gist-by-id"
+  from = "/api/gists/create"
+  to = "/.netlify/functions/gists-create"
   status = 200
 
 [[redirects]]
-  from = "/api/gists/create"
-  to = "/.netlify/functions/gists-create"
+  from = "/api/gists/:id"
+  to = "/.netlify/functions/gist-by-id"
   status = 200
 
 [[redirects]]


### PR DESCRIPTION
Move /api/gists/create redirect before /api/gists/:id in netlify.toml so the literal path matches before the wildcard. Previously, 'create' was matched as an :id parameter, routing POST requests to gist-by-id which returned 405.