### PR TITLE
Style inline code blocks with background, border, and padding

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -91,6 +91,21 @@ body {
 	font-size: 1.2em;
 }
 
+/* Inline code */
+.markdown-preview :not(pre) > code {
+	background-color: #f3f4f6;
+	border: 1px solid #e5e7eb;
+	border-radius: 0.25rem;
+	padding: 0.125rem 0.375rem;
+	font-size: 0.875em;
+	font-family:
+		"SF Mono", "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular,
+		Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+	font-weight: 500;
+	color: #1f2937;
+	word-break: break-word;
+}
+
 /* Footnotes */
 .markdown-preview [data-footnote-ref] {
 	font-size: 0.75em;


### PR DESCRIPTION
## Summary

Adds proper styling for inline  elements in the markdown preview, addressing #29.

### Changes

- Added CSS rule targeting  to style only inline code (not fenced code blocks)
- Light gray background () with subtle border () for visual distinction
- Rounded corners () and horizontal padding () for comfortable readability
- Monospace font stack matching the editor's font family for consistency
-  (medium) instead of bold for a cleaner look
-  to prevent long inline code from overflowing

### Before / After

Before: Inline code only appears as bold text with no visual container.
After: Inline code gets a distinct gray pill-style background, making it clearly distinguishable from regular text.

Closes #29