### PR TITLE
Replace expand-on-hover icon buttons with fixed-width buttons + tooltips

### DIFF
--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,5 +1,5 @@
-import { motion } from "framer-motion";
-import { useRef, useState, useEffect, type ReactNode } from "react";
+import { type ReactNode } from "react";
+import Tooltip from "./Tooltip";
 
 interface IconButtonProps {
 	icon: ReactNode;
@@ -11,10 +11,6 @@ interface IconButtonProps {
 	forceExpanded?: boolean;
 }
 
-const ICON_SIZE = 36;
-const GAP = 6;
-const PAD_RIGHT = 10;
-
 export default function IconButton({
 	icon,
 	label,
@@ -22,59 +18,27 @@ export default function IconButton({
 	disabled = false,
 	variant = "default",
 	className = "",
-	forceExpanded = false,
 }: IconButtonProps) {
-	const [hovered, setHovered] = useState(false);
-	const labelRef = useRef<HTMLSpanElement>(null);
-	const [labelWidth, setLabelWidth] = useState(0);
-
-	useEffect(() => {
-		if (labelRef.current) {
-			setLabelWidth(labelRef.current.scrollWidth);
-		}
-	}, [label]);
-
-	const expanded = (hovered || forceExpanded) && !disabled;
-	const targetWidth = expanded
-		? ICON_SIZE + GAP + labelWidth + PAD_RIGHT
-		: ICON_SIZE;
-
 	const baseClasses =
-		"inline-flex items-center h-9 rounded-full cursor-pointer overflow-hidden whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed";
+		"inline-flex items-center justify-center w-9 h-9 rounded-full cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
 
 	const variantClasses =
 		variant === "primary"
 			? "bg-lime-600 text-white hover:bg-lime-700"
 			: "text-gray-700 hover:bg-gray-100";
-	const expandedClasses = variant === "default" && expanded ? "bg-gray-100" : "";
-
-	const spring = { type: "spring" as const, stiffness: 500, damping: 30 };
 
 	return (
-		<motion.button
-			className={`${baseClasses} ${variantClasses} ${expandedClasses} ${className}`}
-			onClick={onClick}
-			disabled={disabled}
-			onMouseEnter={() => setHovered(true)}
-			onMouseLeave={() => setHovered(false)}
-			onFocus={() => setHovered(true)}
-			onBlur={() => setHovered(false)}
-			title={label}
-			animate={{ width: targetWidth }}
-			transition={spring}
-			style={{ minWidth: ICON_SIZE }}
-		>
-			<span className="flex-shrink-0 flex items-center justify-center w-9 h-9">
-				{icon}
-			</span>
-			<motion.span
-				ref={labelRef}
-				className="text-sm font-medium"
-				animate={{ opacity: expanded ? 1 : 0 }}
-				transition={{ duration: expanded ? 0.15 : 0.1 }}
+		<Tooltip label={label}>
+			<button
+				className={`${baseClasses} ${variantClasses} ${className}`}
+				onClick={onClick}
+				disabled={disabled}
+				aria-label={label}
 			>
-				{label}
-			</motion.span>
-		</motion.button>
+				<span className="flex items-center justify-center w-9 h-9">
+					{icon}
+				</span>
+			</button>
+		</Tooltip>
 	);
 }

--- a/src/components/Navbar/SplitDownloadButton.tsx
+++ b/src/components/Navbar/SplitDownloadButton.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useRef, useState } from "react";
-import { ChevronDown, Download } from "lucide-react";
-import { motion } from "framer-motion";
+import { Download, ChevronDown } from "lucide-react";
+import Tooltip from "../Tooltip";
 
 interface SplitDownloadButtonProps {
 	onDownloadMarkdown: () => void;
@@ -8,73 +7,34 @@ interface SplitDownloadButtonProps {
 	menuOpen: boolean;
 }
 
-const ICON_SIZE = 36;
-const CARET_SIZE = 30;
-const GAP = 6;
-const PAD_RIGHT = 4;
-
 export default function SplitDownloadButton({
 	onDownloadMarkdown,
 	onOpenMenu,
 	menuOpen,
 }: SplitDownloadButtonProps) {
-	const [hovered, setHovered] = useState(false);
-	const labelRef = useRef<HTMLSpanElement>(null);
-	const [labelWidth, setLabelWidth] = useState(0);
-
-	useEffect(() => {
-		if (labelRef.current) {
-			setLabelWidth(labelRef.current.scrollWidth);
-		}
-	}, []);
-
-	const expanded = hovered || menuOpen;
-	const targetWidth = expanded
-		? ICON_SIZE + GAP + labelWidth + PAD_RIGHT + CARET_SIZE
-		: ICON_SIZE;
-	const spring = { type: "spring" as const, stiffness: 500, damping: 30 };
-
 	return (
-		<motion.div
-			className={`inline-flex items-center justify-between h-9 rounded-full overflow-hidden text-gray-700 hover:bg-gray-100 ${expanded ? "bg-gray-100" : ""}`}
-			onMouseEnter={() => setHovered(true)}
-			onMouseLeave={() => setHovered(false)}
-			animate={{ width: targetWidth }}
-			transition={spring}
-			style={{ minWidth: ICON_SIZE }}
-		>
-			<button
-				onClick={onDownloadMarkdown}
-				className="inline-flex items-center justify-between h-9 cursor-pointer"
-				title="Download"
+		<Tooltip label="Download">
+			<div
+				className={`inline-flex items-center h-9 rounded-full overflow-hidden text-gray-700 transition-colors hover:bg-gray-100 ${menuOpen ? "bg-gray-100" : ""}`}
 			>
-				<span className="flex-shrink-0 flex items-center justify-center w-9 h-9">
-					<Download size={18} />
-				</span>
-				<motion.span
-					ref={labelRef}
-					className="text-sm font-medium whitespace-nowrap mr-2"
-					animate={{ opacity: expanded ? 1 : 0 }}
-					transition={{ duration: expanded ? 0.15 : 0.1 }}
+				<button
+					onClick={onDownloadMarkdown}
+					className="inline-flex items-center justify-center w-9 h-9 cursor-pointer"
+					aria-label="Download Markdown"
 				>
-					Download
-				</motion.span>
-			</button>
-			<motion.button
-				onClick={(e) => {
-					e.stopPropagation();
-					onOpenMenu();
-				}}
-				className={`flex-shrink-0 flex items-center justify-center h-9 w-7 border-l border-gray-200 cursor-pointer hover:bg-gray-200 ${menuOpen ? "bg-gray-200" : ""}`}
-				animate={{
-					opacity: expanded ? 1 : 0,
-					width: expanded ? CARET_SIZE : 0,
-				}}
-				transition={spring}
-				aria-label="More download options"
-			>
-				<ChevronDown size={14} />
-			</motion.button>
-		</motion.div>
+					<Download size={18} />
+				</button>
+				<button
+					onClick={(e) => {
+						e.stopPropagation();
+						onOpenMenu();
+					}}
+					className={`flex items-center justify-center h-9 w-7 border-l border-gray-200 cursor-pointer hover:bg-gray-200 ${menuOpen ? "bg-gray-200" : ""}`}
+					aria-label="More download options"
+				>
+					<ChevronDown size={14} />
+				</button>
+			</div>
+		</Tooltip>
 	);
 }

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -118,7 +118,7 @@ export default function Navbar({
 									}
 									label="File"
 									onClick={() => setIsFileMenuOpen((prev) => !prev)}
-									forceExpanded={isFileMenuOpen}
+	
 								/>
 							}
 							onNew={onNew}

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,74 @@
+import { motion, AnimatePresence } from "framer-motion";
+import { useState, useRef, useEffect, type ReactNode } from "react";
+
+interface TooltipProps {
+	label: string;
+	children: ReactNode;
+	delay?: number;
+}
+
+export default function Tooltip({ label, children, delay = 400 }: TooltipProps) {
+	const [visible, setVisible] = useState(false);
+	const timeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const tooltipRef = useRef<HTMLDivElement>(null);
+	const [nudge, setNudge] = useState(0);
+
+	const show = () => {
+		timeoutRef.current = setTimeout(() => setVisible(true), delay);
+	};
+
+	const hide = () => {
+		if (timeoutRef.current) clearTimeout(timeoutRef.current);
+		setVisible(false);
+	};
+
+	useEffect(() => {
+		return () => {
+			if (timeoutRef.current) clearTimeout(timeoutRef.current);
+		};
+	}, []);
+
+	useEffect(() => {
+		if (visible && tooltipRef.current) {
+			const rect = tooltipRef.current.getBoundingClientRect();
+			const overflow = rect.right - window.innerWidth + 8;
+			if (overflow > 0) {
+				setNudge(-overflow);
+			} else if (rect.left < 8) {
+				setNudge(8 - rect.left);
+			} else {
+				setNudge(0);
+			}
+		}
+	}, [visible]);
+
+	return (
+		<div
+			ref={containerRef}
+			className="relative inline-flex"
+			onMouseEnter={show}
+			onMouseLeave={hide}
+			onFocus={show}
+			onBlur={hide}
+		>
+			{children}
+			<AnimatePresence>
+				{visible && (
+					<motion.div
+						ref={tooltipRef}
+						role="tooltip"
+						initial={{ opacity: 0, y: -2 }}
+						animate={{ opacity: 1, y: 0 }}
+						exit={{ opacity: 0, y: -2 }}
+						transition={{ duration: 0.15 }}
+						className="absolute top-full left-1/2 mt-2 px-2 py-1 text-xs font-medium text-white bg-gray-900 rounded shadow-lg whitespace-nowrap pointer-events-none z-50"
+						style={{ transform: `translateX(calc(-50% + ${nudge}px))` }}
+					>
+						{label}
+					</motion.div>
+				)}
+			</AnimatePresence>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

- Replaces the expand-on-hover icon buttons with fixed-width (36px) icon-only buttons that show a tooltip below on hover
- Eliminates the layout shift problem where hovering "About FancyGist" would push "File" and other buttons out of position
- Adds proper `aria-label` attributes on all icon buttons for screen reader accessibility

## Problem

The previous `IconButton` component animated its width via a Framer Motion spring to reveal a text label on hover. Because buttons are in a flex container with `gap-2`, expanding one button shifted all siblings to the right. Hovering "About FancyGist" (the widest label) displaced "File" entirely, making it impossible to click without the target moving.

## Solution

- **New `Tooltip` component** (`src/components/Tooltip.tsx`) -- a reusable tooltip that appears below the trigger after a 400ms delay, with Framer Motion fade animation and automatic horizontal nudging to stay within the viewport.
- **Refactored `IconButton`** -- removed all width animation, label measurement, `forceExpanded`, and hover state logic. Now a static 36x36px circle button wrapped in `<Tooltip>`.
- **Refactored `SplitDownloadButton`** -- same treatment; the split button (download icon + chevron) is now fixed-width with a tooltip.
- **Navbar cleanup** -- removed the `forceExpanded` prop from the File menu trigger.

This follows standard toolbar UX conventions used by VS Code, Figma, Slack, and similar tools.

![Kapture 2026-03-23 at 10 39 14](https://github.com/user-attachments/assets/7b0c09ce-3566-40e6-ba9d-cb215c6cba12)
